### PR TITLE
compilebench: print both wall and user time elapsed

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,10 +300,13 @@ func runBuild(name, dir string) {
 		os.Remove(pkg.Dir + "/_compilebench_.cpuprof")
 	}
 
+	wallns := end.Sub(start).Nanoseconds()
+	userns := cmd.ProcessState.UserTime().Nanoseconds()
+
 	if *flagAlloc {
-		fmt.Printf("%s 1 %d ns/op %d B/op %d allocs/op\n", name, end.Sub(start).Nanoseconds(), bytes, allocs)
+		fmt.Printf("%s 1 %d ns/op %d user-ns/op %d B/op %d allocs/op\n", name, wallns, userns, bytes, allocs)
 	} else {
-		fmt.Printf("%s 1 %d ns/op\n", name, end.Sub(start).Nanoseconds())
+		fmt.Printf("%s 1 %d ns/op %d user-ns/op\n", name, wallns, userns)
 	}
 
 	os.Remove(pkg.Dir + "/_compilebench_.o")


### PR DESCRIPTION
@bradfitz or @rsc please to review.

benchstat does the right thing with user-ns/op, and benchcmp ignores it, which is good enough.

Sample output:

``` bash
$ compilebench -alloc
BenchmarkTemplate 1 415676545 ns/op 497528000 user-ns/op 57576960 B/op 504773 allocs/op
BenchmarkUnicode 1 184991575 ns/op 255675000 user-ns/op 41150400 B/op 400863 allocs/op
BenchmarkGoTypes 1 1150293771 ns/op 1562683000 user-ns/op 192223776 B/op 1511426 allocs/op
BenchmarkCompiler 1 5706963651 ns/op 7717745000 user-ns/op 843172176 B/op 6122181 allocs/op
BenchmarkMakeBash 1 60015805634 ns/op
BenchmarkHelloSize 1 557056 text-bytes 128288 data-bytes 901024 exe-bytes
BenchmarkCmdGoSize 1 6225920 text-bytes 281088 data-bytes 9640396 exe-bytes
```
